### PR TITLE
Add example `exclude` quality config parameter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,15 @@
     },
     "todo-tree.filtering.excludeGlobs": [
         "**/templates/**", // Prevent template TODOs from polluting developer workspace
-    ]
+    ],
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/Thumbs.db": true,
+        "**/__pycache__": true,
+        "**/*.pyc": true
+    }
 }

--- a/ingest/example_ingest_pnnl/config/pipeline_config_example_ingest_pnnl.yml
+++ b/ingest/example_ingest_pnnl/config/pipeline_config_example_ingest_pnnl.yml
@@ -1,15 +1,31 @@
 pipeline:
-  type: Ingest
+  # The 'pipeline' section defines some high-level parameters that are mostly just used
+  # to name the files that this pipeline produces. Our file naming conventions dictate
+  # that output (processed) files are named like:
+  # <location_id>.<dataset_name>[-qualifier][-temporal].<data_level>.<YYYYMMDD>.<HHMMSS>.<extension>
 
-  # These parameters will be used to name files.
+  type: Ingest
   location_id: "pnnl"
   dataset_name: "example_ingest"
   # qualifier: ""
   # temporal: ""
-  data_level: "b1"  # If not applying QC this should be set to "a1"
+  data_level: "b1" # If not applying QC this should be set to "a1"
+
+# --------------------------------------------------------------------------------------
 
 dataset_definition:
+  # The 'dataset_definition' section describes the metadata and variable structure that
+  # the output dataset will take. This section is based on the netCDF standard such that
+  # for each output dataset there are global attributes, dimensions, coordinate
+  # variables, and data variables. The actual structure the output dataset takes is
+  # determined by the output FileHandler selected in the storage configuration file (by
+  # default it is netCDF, so the structure and metadata here is preserved).
+
   attributes:
+    # The 'attributes' section defines the global attributes that will appear in the
+    # output dataset. It is recommended to include at least the attributes listed below
+    # in your configuration files, and we always encourage adding more information that
+    # helps your users understand the context in which the data were obtained.
     title: "Example Ingest"
     description: "This is an example ingest meant to demonstrate how one might set up an ingestion pipeline using this template repository. It should be deleted before this repository or any of its ingests are used in a production environment."
     conventions: MHKiT-Cloud Data Standards v. 1.0
@@ -18,46 +34,71 @@ dataset_definition:
     location_meaning: "Pacific Northwest National Laboratory"
 
   dimensions:
+    # The 'dimensions' section defines the shape of your dataset. It is expected that
+    # 'time' is always a dimension, but you may have as many additional dimensions as
+    # you would like.
     time:
-        length: unlimited
+      length: unlimited
 
   variables:
+    # The 'variables' section defines the metadata and retrieval rules for measurements
+    # that are reported in your output dataset. Each variable configuration block
+    # consists of 3-5 main components:
+    #
+    # 1) input [optional] - tells tsdat how the variable should be retrieved. You can
+    # leave this out if you want to populate the variable's data manually.
+    # 2) data [optional] - used to set the variable's data directly in this config file,
+    # which is useful for scalar properties (like altitude or lat/lon).
+    # 3) dims – tells tsdat what shape this data has.
+    # 4) type – this is the np.dtype of the variable.
+    # 5) attrs – metadata that describes this variable.
+    #
+    # You can leave off both items 1 and 2 to have tsdat initialize the variable as an
+    # empty array. This is useful if you want to add data to your output file that isn't
+    # directly retrieved from the input dataset.
 
     time:
+      # The time coordinate variable is required in every dataset processed by tsdat
       input:
+        # The input section describes how the data should be retrieved from the input
+        # file. Here we say that 'time' is named 'Timestamp (end of interval)' in the
+        # input file. We also specify how the data should be converted from the input
+        # to output; in this case we specify how to convert the time strings from the
+        # input into a python datetime object.
         name: Timestamp (end of interval)
         converter:
           classname: tsdat.utils.converters.StringTimeConverter
           parameters:
             timezone: UTC
             time_format: "%Y-%m-%d %H:%M:%S"
-      dims: [time]
+
+      dims: [time] # 'time' is a coordinate variable, so it is dimensioned by 'time'
+
+      # 'time' should be a 'long' data type, since in this case it is the number of
+      # seconds since 1970, which is very common and standard way to represent time.
       type: long
+
       attrs:
+        # Here we define some helpful attributes for users and machines. Typically you
+        # should always define a long_name (used for plot labels), a standard_name (used
+        # to standardize variable across datasets according to CF Conventions), and
+        # units (https://github.com/hgrecco/pint/blob/master/pint/default_en.txt)
         long_name: Time (UTC)
         standard_name: time
         units: seconds since 1970-01-01T00:00:00
-    
-    example_var:          # Name of variable in the output file
+
+    example_var:
       input:
-        name: "Example"   # Name of variable in the input file
-        # units: m        # Units the input variable was measured in. Provide this if 
-                          # the output units are different and you want tsdat to do the
-                          # conversion.
-      dims: [time]        # List of coordinates that dimension this variable. `time` is
-                          # a very common dimension, sometimes `height`, too.
-      type: float         # The data type, typically one of: `float`, `long`, `int`
+        name: "Example"
+        units: km
+      dims: [time]
+      type: float
       attrs:
-        long_name: Example Var  # Label used by Xarray and other libraries for plotting
-        standard_name: ""       # Standard name from the CF Standard names table. 
-                                # Provide this if possible, otherwise remove it.
-        comment: ""             # User-friendly description of the property.
-        units: km               # Units attribute from the CF Standard list of units. 
-                                # Always provide this, even for 'unitless' quantities –
-                                # set `units: "1"` for such quantities.
-    
+        long_name: Example Var
+        units: km
+
     latitude:
-      data: 39.90891
+      data: 39.90891 # You can specify the data value directly like this
       type: float
       attrs:
         long_name: "North latitude"
@@ -75,7 +116,7 @@ dataset_definition:
         comment: "Recorded longitude at the instrument location"
         units: "degree_E"
         valid_range: [-180.f, 180.f]
-    
+
     altitude:
       data: 1828.8
       type: float
@@ -84,17 +125,30 @@ dataset_definition:
         standard_name: "altitude"
         comment: "Recorded altitude at the instrument location"
         units: m
-    
-#-----------------------------------------------------------------
-quality_management:
 
-  #---------------------------------------------------------------
+# --------------------------------------------------------------------------------------
+
+quality_management:
+  # This section of the pipeline configuration file is all about detecting and managing
+  # data quality issues. Each config block has three main sections:
+  #
+  # 1) checker - tells tsdat what QualityChecker to use to detect quality issues
+  # 2) handlers - tells tsdat which QualityHandler(s) to use to handle quality issues
+  # 3) variables / exclude - tells tsdat which variables should be checked
+
   manage_missing_coordinates:
     checker:
+      # Tells tsdat which QualityChecker should be used to identify quality issues. Here
+      # we use the built-in CheckMissing class in the tsdat.qc.checkers module.
       classname: tsdat.qc.checkers.CheckMissing
     handlers:
+      # Tells tsdat which QualityHandler(s) should be used to handle quality issues. In
+      # this case we only use one handler, which fails the pipeline.
       - classname: tsdat.qc.handlers.FailPipeline
     variables:
+      # COORDS is a keyword which tells tsdat to only run this quality manager for
+      # coordinate variables, which are just variables that also are dimensions. In this
+      # dataset 'time' is the only coordinate variable.
       - COORDS
 
   manage_coordinate_monotonicity:
@@ -108,17 +162,38 @@ quality_management:
     variables:
       - COORDS
 
-  #---------------------------------------------------------------
   manage_missing_values:
     checker:
       classname: tsdat.qc.checkers.CheckMissing
+
     handlers:
+      # The RemoveFailedValues handler replaces values that are missing with the
+      # variable's _FillValue (from CF Conventions), which defaults to -9999. Xarray and
+      # other netCDF libraries will interpret this as a NaN.
       - classname: tsdat.qc.handlers.RemoveFailedValues
+
+      # For each variable the RecordQualityResults handler is applied to, a qc variable
+      # is created (or updated, if it exists) whose purpose is to track the specific
+      # test(s) and data indexes that failed. It uses a bit-packing approach to store
+      # the results of tests.
       - classname: tsdat.qc.handlers.RecordQualityResults
         parameters:
           bit: 1
           assessment: Bad
           meaning: "Value is equal to _FillValue or NaN"
+
     variables:
+      # DATA_VARS is a keyword which tells tsdat to only run this quality manager for
+      # data variables, which are all non-coordinate variables are dimensions. In this
+      # dataset 'example_var', 'latitude', 'longitude', and 'altitude' are all data
+      # variables
       - DATA_VARS
-    exclude: [latitude, longitude, altitude]
+
+    exclude:
+      # The exclude keyword tells tsdat to skip this check for specific variables that
+      # would otherwise have been selected. Note that here we opt to skip the latitude,
+      # longitude, and altitude variables since we set their data values in this config
+      # file - no need to analyze the quality of that data, we already know it's valid.
+      - latitude
+      - longitude
+      - altitude

--- a/ingest/example_ingest_pnnl/config/storage_config_example_ingest_pnnl.yml
+++ b/ingest/example_ingest_pnnl/config/storage_config_example_ingest_pnnl.yml
@@ -24,22 +24,6 @@ storage:
     # to use as it sees fit.
 
     input:
-      my_custom_format:
-        # This is where you define/configure your custom FileHandler for use in your
-        # pipeline. At a minimum, you should update the file_pattern and classname
-        # options so that they match your data and python class name, respectively. We
-        # also recommend adding parameters if possible so that your code is more
-        # modular and reusable. See the csv configuration below as well as the tsdat
-        # CsvHandler implementation for more information as needed.
-        file_pattern: '.*\.custom_extension'
-        classname: ingest.{{ cookiecutter.ingest_slug }}.pipeline.filehandler.CustomFileHandler
-        # parameters:
-        #   # If you choose, you can define parameters here that will be available for
-        #   # you to use in your custom FileHandler. This is entirely optional, but we
-        #   # highly recommend making good use of it.
-        #   read:
-        #     some_custom_option: True
-
       csv:
         # Here we define single FileHandler for reading input data. The FileHandler is
         # configured to run for files ending in '.csv' and uses the built-in

--- a/ingest/example_ingest_pnnl/config/storage_config_example_ingest_pnnl.yml
+++ b/ingest/example_ingest_pnnl/config/storage_config_example_ingest_pnnl.yml
@@ -1,34 +1,67 @@
-
 storage:
-
-  # This section should not be modified unless there is a strong need. Please contact
-  # the repository maintainers if you feel you need to use different settings here –
-  # there may be another way to accomplish what you need.
-  classname:  ${STORAGE_CLASSNAME}
+  # This section should not be modified unless there is a strong need. It is set up to
+  # use environment variables to set the settings. These variables are automatically set
+  # by the various entry points to this ingest and should not be modified unless you
+  # know what you are doing.
+  classname: ${STORAGE_CLASSNAME}
   parameters:
     retain_input_files: ${RETAIN_INPUT_FILES}
     root_dir: ${ROOT_DIR}
     bucket_name: ${STORAGE_BUCKET}
 
   file_handlers:
+    # FileHandlers are split into two categories: those used for reading input, and
+    # those meant for writing output files. Each FileHandler configuration block
+    # consists of the following components:
+    #
+    # 1) label (e.g. 'netcdf') - solely used for orgnaization within this config file
+    # 2) file_pattern - a regex string (or list of strings) for which the FileHandler
+    # should be used. Only applicable for input FileHandlers.
+    # 3) file_extension - the file extension. Used in output FileHandlers, but also
+    # can be used in place of a file_pattern for input FileHandlers.
+    # 4) classname - tells which FileHandler should be used
+    # 5) parameters - additonal parameters that will be passed to the FileHandler for it
+    # to use as it sees fit.
 
     input:
+      my_custom_format:
+        # This is where you define/configure your custom FileHandler for use in your
+        # pipeline. At a minimum, you should update the file_pattern and classname
+        # options so that they match your data and python class name, respectively. We
+        # also recommend adding parameters if possible so that your code is more
+        # modular and reusable. See the csv configuration below as well as the tsdat
+        # CsvHandler implementation for more information as needed.
+        file_pattern: '.*\.custom_extension'
+        classname: ingest.{{ cookiecutter.ingest_slug }}.pipeline.filehandler.CustomFileHandler
+        # parameters:
+        #   # If you choose, you can define parameters here that will be available for
+        #   # you to use in your custom FileHandler. This is entirely optional, but we
+        #   # highly recommend making good use of it.
+        #   read:
+        #     some_custom_option: True
 
       csv:
-        file_pattern: '.*\.csv'                       # Matches files ending in '.csv'
-        classname: tsdat.io.filehandlers.CsvHandler   # FileHandler module to use
-        parameters:     # Parameters to pass to CsvHandler. Comment out if not using.
+        # Here we define single FileHandler for reading input data. The FileHandler is
+        # configured to run for files ending in '.csv' and uses the built-in
+        # CsvHandler from the tsdat.io.filehandlers module with some specific parameters
+        # that help us read data from our example csv file.
+        file_pattern: '.*\.csv'
+        classname: tsdat.io.filehandlers.CsvHandler
+        parameters:
           read:
-            # You can add parameters that are passed to pandas.read_csv() as kwargs:
+            # You can add parameters that are passed to pandas.read_csv() as keyword
+            # arguments. See the pandas.read_csv() docs for more details.
             read_csv:
-              index_col: False      # Treat the first column (time) as a data variable
-              header: 2             # Where to look for the header (header line number - 1) 
+              index_col: False # Treat the first column (time) as a data variable
+              header: 2 # Where to look for the header (header = line number - 1)
 
-    
-    # The output section should not be modified unless there is a strong need. Please
-    # contact the repository maintainers if you feel you need to write to a different
-    # format.
+    # We highly recommend writing to the netcdf format whenever possible, as this format
+    # preserves the data structure and metadata as configured in the pipeline config
+    # file, however we recognize that sometimes this is not possible. Our recommendation
+    # in these situations is to just be aware that many formats (such as csv) do not
+    # support embedding metadata into your output files, so you should careful consider
+    # how metadata is captured and reported so as to avoid data loss.
     output:
       netcdf:
-        file_extension: '.nc'
+        file_extension: ".nc"
         classname: tsdat.io.filehandlers.NetCdfHandler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tsdat == 0.2.10
+tsdat == 0.2.12
 netcdf4
 xarray
 numpy

--- a/templates/ingest/README.md
+++ b/templates/ingest/README.md
@@ -28,5 +28,6 @@ the documentation below for more information regarding these prompts.
 | `ingest`                 | `Ingest Name`         | Verbose name of the ingest. Used in README.md                                                                                       |
 | `ingest_slug`            | `ingest_name`         | Name used for the ingest module. Should take the format: `type_make_model_loc` (e.g., `lidar_halo_xrp_nwtc`)                        |
 | `description`            | `description`         | A brief description of the ingest. Used in README.md                                                                                |
-| `use_custom_filehandler` | `yes`                 | Flag to generate a custom FileHandler template. Use this if data cannot be read in using out-of-box FileHandlers provided by tsdat. |
-| `use_custom_qc`          | `yes`                 | Flag to generate a custom QC template module. Use this if you want to apply custom quality checks or handlers.                      |
+| `use_custom_filehandler` | `no`                  | Flag to generate a custom FileHandler template. Use this if data cannot be read in using out-of-box FileHandlers provided by tsdat. |
+| `use_custom_qc`          | `no`                  | Flag to generate a custom QC template module. Use this if you want to apply custom quality checks or handlers.                      |
+| `add_help`               | `yes`                 | Flag to generate additional help text (i.e. descriptions of config file properties, extra comments, etc).                           |

--- a/templates/ingest/cookiecutter.json
+++ b/templates/ingest/cookiecutter.json
@@ -13,5 +13,9 @@
     "use_custom_qc": [
         "no",
         "yes"
+    ],
+    "add_help": [
+        "yes",
+        "no"
     ]
 }

--- a/templates/ingest/{{ cookiecutter.ingest_slug }}/config/pipeline_config_{{ cookiecutter.ingest_slug }}.yml
+++ b/templates/ingest/{{ cookiecutter.ingest_slug }}/config/pipeline_config_{{ cookiecutter.ingest_slug }}.yml
@@ -134,4 +134,7 @@ quality_management:
     checker:
       classname: ingest.{{ cookiecutter.ingest_slug }}.pipeline.qc.CustomQualityChecker
     handlers:
-      - classname: ingest.{{ cookiecutter.ingest_slug }}.pipeline.qc.CustomQualityHandler{% endif %}
+      - classname: ingest.{{ cookiecutter.ingest_slug }}.pipeline.qc.CustomQualityHandler
+    variables:
+     - DATA_VARS
+    exclude: [latitude, longitude, altitude]{% endif %}

--- a/templates/ingest/{{ cookiecutter.ingest_slug }}/config/pipeline_config_{{ cookiecutter.ingest_slug }}.yml
+++ b/templates/ingest/{{ cookiecutter.ingest_slug }}/config/pipeline_config_{{ cookiecutter.ingest_slug }}.yml
@@ -4,18 +4,34 @@
 # the some projects may use slightly different metadata conventions and requirements
 # than tsdat.
 
-pipeline:
-  type: Ingest
+pipeline: {% if cookiecutter.add_help == "yes" %}
+  # The 'pipeline' section defines some high-level parameters that are mostly just used
+  # to name the files that this pipeline produces. Our file naming conventions dictate
+  # that output (processed) files are named like:
+  # <location_id>.<dataset_name>[-qualifier][-temporal].<data_level>.<YYYYMMDD>.<HHMMSS>.<extension>{% endif %}
 
-  # These parameters will be used to name files.
+  type: Ingest
   location_id: "{{ cookiecutter.location_slug }}"
   dataset_name: "{{ cookiecutter.ingest | slugify(separator='_') }}"
   # qualifier: ""
   # temporal: ""
-  data_level: "b1"  # If not applying QC this should be set to "a1"
+  data_level: "b1"  # If not applying any QC this should be set to "a1"
 
-dataset_definition:
-  attributes:
+# --------------------------------------------------------------------------------------
+
+dataset_definition: {% if cookiecutter.add_help == "yes" %}
+  # The 'dataset_definition' section describes the metadata and variable structure that
+  # the output dataset will take. This section is based on the netCDF standard such that
+  # for each output dataset there are global attributes, dimensions, coordinate
+  # variables, and data variables. The actual structure the output dataset takes is
+  # determined by the output FileHandler selected in the storage configuration file (by
+  # default it is netCDF, so the structure and metadata here is preserved).{% endif %}
+
+  attributes: {% if cookiecutter.add_help == "yes" %}
+    # The 'attributes' section defines the global attributes that will appear in the
+    # output dataset. It is recommended to include at least the attributes listed below
+    # in your configuration files, and we always encourage adding more information that
+    # helps your users understand the context in which the data were obtained.{% endif %}
     title: "{{ cookiecutter.ingest }}"
     description: "{{ cookiecutter.description }}"
     conventions: MHKiT-Cloud Data Standards v. 1.0
@@ -23,47 +39,72 @@ dataset_definition:
     code_url: https://github.com/tsdat/ingest-template
     location_meaning: "{{ cookiecutter.location }}"
 
-  dimensions:
+  dimensions: {% if cookiecutter.add_help == "yes" %}
+    # The 'dimensions' section defines the shape of your dataset. It is expected that
+    # 'time' is always a dimension, but you may have as many additional dimensions as
+    # you would like.{% endif %}
     time:
         length: unlimited
 
-  variables:
-
-    time:
-      input:
+  variables: {% if cookiecutter.add_help == "yes" %}
+    # The 'variables' section defines the metadata and retrieval rules for measurements
+    # that are reported in your output dataset. Each variable configuration block
+    # consists of 3-5 main components:
+    #
+    # 1) input [optional] - tells tsdat how the variable should be retrieved. You can
+    # leave this out if you want to populate the variable's data manually.
+    # 2) data [optional] - used to set the variable's data directly in this config file,
+    # which is useful for scalar properties (like altitude or lat/lon).
+    # 3) dims – tells tsdat what shape this data has.
+    # 4) type – this is the np.dtype of the variable.
+    # 5) attrs – metadata that describes this variable.
+    #
+    # You can leave off both items 1 and 2 to have tsdat initialize the variable as an
+    # empty array. This is useful if you want to add data to your output file that isn't
+    # directly retrieved from the input dataset.
+    {% endif %}
+    time: {% if cookiecutter.add_help == "yes" %}
+      # The time coordinate variable is required in every dataset processed by tsdat{% endif %}
+      input: {% if cookiecutter.add_help == "yes" %}
+        # The input section describes how the data should be retrieved from the input
+        # file. Here we say that 'time' is named 'Timestamp (end of interval)' in the
+        # input file. We also specify how the data should be converted from the input
+        # to output; in this case we specify how to convert the time strings from the
+        # input into a python datetime object.{% endif %}
         name: Timestamp (end of interval)
         converter:
           classname: tsdat.utils.converters.StringTimeConverter
           parameters:
             timezone: UTC
-            time_format: "%Y-%m-%d %H:%M:%S"
-      dims: [time]
-      type: long
-      attrs:
+            time_format: "%Y-%m-%d %H:%M:%S" {% if cookiecutter.add_help == "yes" %}
+      {%endif%}
+      dims: [time] {% if cookiecutter.add_help == "yes" %}# 'time' is a coordinate variable, so it is dimensioned by 'time' {% if cookiecutter.add_help == "yes" %}
+      {%endif%}
+      # 'time' should be a 'long' data type, since in this case it is the number of
+      # seconds since 1970, which is very common and standard way to represent time.{% endif%}
+      type: long {% if cookiecutter.add_help == "yes" %}
+      {%endif%}
+      attrs: {% if cookiecutter.add_help == "yes" %}
+        # Here we define some helpful attributes for users and machines. Typically you
+        # should always define a long_name (used for plot labels), a standard_name (used
+        # to standardize variable across datasets according to CF Conventions), and
+        # units (https://github.com/hgrecco/pint/blob/master/pint/default_en.txt){% endif %}
         long_name: Time (UTC)
         standard_name: time
         units: seconds since 1970-01-01T00:00:00
-    
-    example_var:          # Name of variable in the output file
+
+    example_var:
       input:
-        name: "Example"   # Name of variable in the input file
-        # units: m        # Units the input variable was measured in. Provide this if 
-                          # the output units are different and you want tsdat to do the
-                          # conversion.
-      dims: [time]        # List of coordinates that dimension this variable. `time` is
-                          # a very common dimension, sometimes `height`, too.
-      type: float         # The data type, typically one of: `float`, `long`, `int`
+        name: "Example"
+        units: km
+      dims: [time]
+      type: float
       attrs:
-        long_name: Example Var  # Label used by Xarray and other libraries for plotting
-        standard_name: ""       # Standard name from the CF Standard names table. 
-                                # Provide this if possible, otherwise remove it.
-        comment: ""             # User-friendly description of the property.
-        units: km               # Units attribute from the CF Standard list of units. 
-                                # Always provide this, even for 'unitless' quantities –
-                                # set `units: "1"` for such quantities.
-    
+        long_name: Example Var
+        units: km
+
     latitude:
-      data: 39.90891
+      data: 39.90891 {% if cookiecutter.add_help == "yes" %}# You can specify the data value directly like this{% endif %}
       type: float
       attrs:
         long_name: "North latitude"
@@ -91,16 +132,29 @@ dataset_definition:
         comment: "Recorded altitude at the instrument location"
         units: m
     
-#-----------------------------------------------------------------
-quality_management:
+# --------------------------------------------------------------------------------------
 
-  #---------------------------------------------------------------
+quality_management: {% if cookiecutter.add_help == "yes" %}
+  # This section of the pipeline configuration file is all about detecting and managing
+  # data quality issues. Each config block has three main sections:
+  #
+  # 1) checker - tells tsdat what QualityChecker to use to detect quality issues
+  # 2) handlers - tells tsdat which QualityHandler(s) to use to handle quality issues
+  # 3) variables / exclude - tells tsdat which variables should be checked{% endif %}
+
   manage_missing_coordinates:
-    checker:
+    checker: {% if cookiecutter.add_help == "yes" %}
+      # Tells tsdat which QualityChecker should be used to identify quality issues. Here
+      # we use the built-in CheckMissing class in the tsdat.qc.checkers module.{% endif %}
       classname: tsdat.qc.checkers.CheckMissing
-    handlers:
+    handlers: {% if cookiecutter.add_help == "yes" %}
+      # Tells tsdat which QualityHandler(s) should be used to handle quality issues. In
+      # this case we only use one handler, which fails the pipeline.{% endif %}
       - classname: tsdat.qc.handlers.FailPipeline
-    variables:
+    variables: {% if cookiecutter.add_help == "yes" %}
+      # COORDS is a keyword which tells tsdat to only run this quality manager for
+      # coordinate variables, which are just variables that also are dimensions. In this
+      # dataset 'time' is the only coordinate variable.{% endif %}
       - COORDS
 
   manage_coordinate_monotonicity:
@@ -114,20 +168,42 @@ quality_management:
     variables:
       - COORDS
 
-  #---------------------------------------------------------------
   manage_missing_values:
     checker:
-      classname: tsdat.qc.checkers.CheckMissing
-    handlers:
-      - classname: tsdat.qc.handlers.RemoveFailedValues
+      classname: tsdat.qc.checkers.CheckMissing {% if cookiecutter.add_help == "yes" %}
+    {%endif%}
+    handlers: {% if cookiecutter.add_help == "yes" %}
+      # The RemoveFailedValues handler replaces values that are missing with the
+      # variable's _FillValue (from CF Conventions), which defaults to -9999. Xarray and
+      # other netCDF libraries will interpret this as a NaN.{% endif %}
+      - classname: tsdat.qc.handlers.RemoveFailedValues {% if cookiecutter.add_help == "yes" %}
+
+      # For each variable the RecordQualityResults handler is applied to, a qc variable
+      # is created (or updated, if it exists) whose purpose is to track the specific
+      # test(s) and data indexes that failed. It uses a bit-packing approach to store
+      # the results of tests.{% endif %}
       - classname: tsdat.qc.handlers.RecordQualityResults
         parameters:
           bit: 1
           assessment: Bad
-          meaning: "Value is equal to _FillValue or NaN"
-    variables:
-      - DATA_VARS
-    exclude: [latitude, longitude, altitude]
+          meaning: "Value is equal to _FillValue or NaN" {% if cookiecutter.add_help == "yes" %}
+    {%endif%}
+    variables: {% if cookiecutter.add_help == "yes" %}
+      # DATA_VARS is a keyword which tells tsdat to only run this quality manager for
+      # data variables, which are all non-coordinate variables are dimensions. In this
+      # dataset 'example_var', 'latitude', 'longitude', and 'altitude' are all data
+      # variables{% endif %}
+      - DATA_VARS {% if cookiecutter.add_help == "yes" %}
+    {%endif%}
+    {% if cookiecutter.add_help == "yes" %}exclude:
+      # The exclude keyword tells tsdat to skip this check for specific variables that
+      # would otherwise have been selected. Note that here we opt to skip the latitude,
+      # longitude, and altitude variables since we set their data values in this config
+      # file - no need to analyze the quality of that data, we already know it's valid.
+      - latitude
+      - longitude
+      - altitude{% endif %}{% if cookiecutter.add_help == "no" %}exclude: [latitude, longitude, altitude]{% endif %}
+    
 {% if cookiecutter.use_custom_qc == "yes" %}
   # TODO – Developer: Update this as needed.
   manage_custom_qc:  # Rename this

--- a/templates/ingest/{{ cookiecutter.ingest_slug }}/config/storage_config_{{ cookiecutter.ingest_slug }}.yml
+++ b/templates/ingest/{{ cookiecutter.ingest_slug }}/config/storage_config_{{ cookiecutter.ingest_slug }}.yml
@@ -1,55 +1,115 @@
-
-storage:
-
-  # This section should not be modified unless there is a strong need. Please contact
-  # the repository maintainers if you feel you need to use different settings here –
-  # there may be another way to accomplish what you need.
-  classname:  ${STORAGE_CLASSNAME}
+{% if cookiecutter.add_help == "yes" %}storage:
+  # This section should not be modified unless there is a strong need. It is set up to
+  # use environment variables to set the settings. These variables are automatically set
+  # by the various entry points to this ingest and should not be modified unless you
+  # know what you are doing.
+  classname: ${STORAGE_CLASSNAME}
   parameters:
     retain_input_files: ${RETAIN_INPUT_FILES}
     root_dir: ${ROOT_DIR}
     bucket_name: ${STORAGE_BUCKET}
 
+  # TODO – Developer: Update the file_handlers as needed
   file_handlers:
+    # FileHandlers are split into two categories: those used for reading input, and
+    # those meant for writing output files. Each FileHandler configuration block
+    # consists of the following components:
+    #
+    # 1) label (e.g. 'netcdf') - solely used for orgnaization within this config file
+    # 2) file_pattern - a regex string (or list of strings) for which the FileHandler
+    # should be used. Only applicable for input FileHandlers.
+    # 3) file_extension - the file extension. Used in output FileHandlers, but also
+    # can be used in place of a file_pattern for input FileHandlers.
+    # 4) classname - tells which FileHandler should be used
+    # 5) parameters - additonal parameters that will be passed to the FileHandler for it
+    # to use as it sees fit.
 
-    input:
-    {% if cookiecutter.use_custom_filehandler not in ["n", "N", "no", "No"] %}
-      # TODO – Developer: Update the FileHandler here as needed
-      my_custom_format:           # Solely used as a label. See the 'csv' input
-                                  # filehandler below 
-        file_pattern: '.*'        # The regex pattern used to match to an input file.
-                                  # Note this will only be applied to files already
-                                  # matched by a mapping in mapping.py, so .* is fine
-                                  # unless you need to use multiple handlers within
-                                  # those matched files.
+    input: {% if cookiecutter.use_custom_filehandler == "yes" %}
+      my_custom_format:
+        # This is where you define/configure your custom FileHandler for use in your
+        # pipeline. At a minimum, you should update the file_pattern and classname
+        # options so that they match your data and python class name, respectively. We
+        # also recommend adding parameters if possible so that your code is more
+        # modular and reusable. See the csv configuration below as well as the tsdat
+        # CsvHandler implementation for more information as needed.
+        file_pattern: '.*\.custom_extension'
         classname: ingest.{{ cookiecutter.ingest_slug }}.pipeline.filehandler.CustomFileHandler
-      
-      # TODO – Developer: Delete this if you don't want to use the CsvHandler
-      # You can also use built-in tsdat FileHandlers, which support a number of custom
-      # parameters: https://tsdat.rtfd.io/en/latest/autoapi/tsdat/io/filehandlers/
+        # parameters:
+        #   # If you choose, you can define parameters here that will be available for
+        #   # you to use in your custom FileHandler. This is entirely optional, but we
+        #   # highly recommend making good use of it.
+        #   read:
+        #     some_custom_option: True
+
       # csv:
-      #   file_pattern: '.*\.csv'                       # Matches files ending in '.csv'
-      #   classname: tsdat.io.filehandlers.CsvHandler   # FileHandler module to use
+      #   # Here we define single FileHandler for reading input data. The FileHandler is
+      #   # configured to run for files ending in '.csv' and uses the built-in
+      #   # CsvHandler from the tsdat.io.filehandlers module with some specific parameters
+      #   # that help us read data from our example csv file.
+      #   file_pattern: '.*\.csv'
+      #   classname: tsdat.io.filehandlers.CsvHandler
       #   parameters:
       #     read:
+      #       # You can add parameters that are passed to pandas.read_csv() as keyword
+      #       # arguments. See the pandas.read_csv() docs for more details.
       #       read_csv:
-      #         # Parameters here will be passed to pd.read_csv() as kwargs
-    {% else %}# TODO – Developer: Update the csv handler as needed
+      #         index_col: False # Treat the first column (time) as a data variable
+      #         header: 2 # Where to look for the header (header = line number - 1){% else %}
       csv:
-        file_pattern: '.*\.csv'                       # Matches files ending in '.csv'
-        classname: tsdat.io.filehandlers.CsvHandler   # FileHandler module to use
-        parameters:     # Parameters to pass to CsvHandler. Comment out if not using.
+        # Here we define single FileHandler for reading input data. The FileHandler is
+        # configured to run for files ending in '.csv' and uses the built-in
+        # CsvHandler from the tsdat.io.filehandlers module with some specific parameters
+        # that help us read data from our example csv file.
+        file_pattern: '.*\.csv'
+        classname: tsdat.io.filehandlers.CsvHandler
+        parameters:
           read:
-            # You can add parameters that are passed to pandas.read_csv() as kwargs:
+            # You can add parameters that are passed to pandas.read_csv() as keyword
+            # arguments. See the pandas.read_csv() docs for more details.
             read_csv:
-              index_col: False      # Treat the first column (time) as a data variable
-              header: 2             # Where to look for the header (header line number - 1) 
+              index_col: False # Treat the first column (time) as a data variable
+              header: 2 # Where to look for the header (header = line number - 1){% endif %}   
 
-    {% endif %}
-    # The output section should not be modified unless there is a strong need. Please
-    # contact the repository maintainers if you feel you need to write to a different
-    # format.
+    output:
+      # We highly recommend writing to the netcdf format whenever possible, as this format
+      # preserves the data structure and metadata as configured in the pipeline config
+      # file, however we recognize that sometimes this is not possible. Our recommendation
+      # in these situations is to just be aware that many formats (such as csv) do not
+      # support embedding metadata into your output files, so you should careful consider
+      # how metadata is captured and reported so as to avoid data loss.
+      
+      netcdf:
+        file_extension: ".nc"
+        classname: tsdat.io.filehandlers.NetCdfHandler
+{% else %}storage:
+  # This section should not be modified unless there is a strong need. It is set up to
+  # use environment variables to set the settings. These variables are automatically set
+  # by the various entry points to this ingest and should not be modified unless you
+  # know what you are doing.
+  classname: ${STORAGE_CLASSNAME}
+  parameters:
+    retain_input_files: ${RETAIN_INPUT_FILES}
+    root_dir: ${ROOT_DIR}
+    bucket_name: ${STORAGE_BUCKET}
+
+  # TODO – Developer: Update the file_handlers as needed
+  file_handlers:
+    input: {% if cookiecutter.use_custom_filehandler == "yes" %}
+      my_custom_format:
+        file_pattern: '.*\.custom_extension'
+        classname: ingest.{{ cookiecutter.ingest_slug }}.pipeline.filehandler.CustomFileHandler{% else %}
+
+      csv:
+        file_pattern: '.*\.csv'
+        classname: tsdat.io.filehandlers.CsvHandler
+        parameters:
+          read:
+            read_csv:
+              index_col: False
+              header: 2{% endif %}
+
     output:
       netcdf:
-        file_extension: '.nc'
+        file_extension: ".nc"
         classname: tsdat.io.filehandlers.NetCdfHandler
+{% endif %}

--- a/templates/ingest/{{ cookiecutter.ingest_slug }}/pipeline/styling.mplstyle
+++ b/templates/ingest/{{ cookiecutter.ingest_slug }}/pipeline/styling.mplstyle
@@ -1,28 +1,26 @@
-# TODO – Maintainer: If you have specific plot style requirements or want to set
-# different defaults for your ingest developers to use, please update those here.
 figure.constrained_layout.use: true
-figure.figsize      : 14, 8
-figure.dpi          : 150
+figure.figsize: 14, 8
+figure.dpi: 150
 
-font.family         : serif
-font.size           : 12
-axes.linewidth      : 2
+font.family: serif
+font.size: 12
+axes.linewidth: 2
 
-legend.frameon      : True
-legend.framealpha   : 1
-legend.edgecolor    : w
+legend.frameon: True
+legend.framealpha: 1
+legend.edgecolor: w
 
-xtick.top           : True
-xtick.alignment     : center
-xtick.minor.visible : True
-xtick.minor.size    : 5
-xtick.major.size    : 8
-xtick.minor.width   : 2
-xtick.major.width   : 2
+xtick.top: True
+xtick.alignment: center
+xtick.minor.visible: True
+xtick.minor.size: 5
+xtick.major.size: 8
+xtick.minor.width: 2
+xtick.major.width: 2
 
-ytick.right         : True
-ytick.minor.visible : True
-ytick.minor.size    : 5
-ytick.major.size    : 8
-ytick.minor.width   : 2
-ytick.major.width   : 2
+ytick.right: True
+ytick.minor.visible: True
+ytick.minor.size: 5
+ytick.major.size: 8
+ytick.minor.width: 2
+ytick.major.width: 2


### PR DESCRIPTION
This PR adds a bit more usage info for how the `exclude` setting can be used in the `quality_management` section of the pipeline config parameter. 

Note that this is already used in the built-in example so the missing value quality check doesn't get run on the `latitude`, `longitude`, and `altitude` variables, but it wasn't included in the Cookiecutter template if you had opted to use a custom `QualityChecker` or `QualityHandler`. This PR fixes that and tries to make things a bit more clear overall.